### PR TITLE
Add support for json output of results

### DIFF
--- a/tests/test_tssv.py
+++ b/tests/test_tssv.py
@@ -2,7 +2,7 @@
 from io import StringIO
 
 from tssv.tssv import parse_library
-from tssv.tssv import clean_allele
+from tssv.tssv import expand_allele
 
 
 class TestTSSV(object):
@@ -26,9 +26,9 @@ class TestTSSV(object):
         assert library['m3']['thresholds'] == [1, 1]
 
     def test_clean_allele(self):
-        raw = ['A', 'AA', 'A(1.0)', 'AA(2.4)']
-        expected = ['A', 'AA', 'A', 'AA']
+        raw = ['A', 'AA', 'A(1.0)', 'AA(2.0)', 'TA(3.0)', 'ATCG(1.0)']
+        expected = ['A', 'AA', 'A', 'AAAA', 'TATATA', 'ATCG']
 
-        out = [clean_allele(x) for x in raw]
+        out = [expand_allele(x) for x in raw]
 
         assert out == expected

--- a/tests/test_tssv.py
+++ b/tests/test_tssv.py
@@ -2,7 +2,6 @@
 from io import StringIO
 
 from tssv.tssv import parse_library
-from tssv.tssv import expand_allele
 
 
 class TestTSSV(object):
@@ -24,13 +23,3 @@ class TestTSSV(object):
     def test_parse_library_with_mismatches(self):
         library = parse_library(open('data/library.csv'), 0.1, 1)
         assert library['m3']['thresholds'] == [1, 1]
-
-    def test_expand_allele(self):
-        raw = ['A', 'AA', 'A(1.0)', 'AA(2.0)', 'TA(3.0)', 'ATCG(1.0)',
-        'ATA(2)GGG(2)C(5)']
-        expected = ['A', 'AA', 'A', 'AAAA', 'TATATA', 'ATCG',
-        'ATAATAGGGGGGCCCCC']
-
-        out = [expand_allele(x) for x in raw]
-
-        assert out == expected

--- a/tests/test_tssv.py
+++ b/tests/test_tssv.py
@@ -2,6 +2,7 @@
 from io import StringIO
 
 from tssv.tssv import parse_library
+from tssv.tssv import make_json_report
 
 
 class TestTSSV(object):
@@ -23,3 +24,11 @@ class TestTSSV(object):
     def test_parse_library_with_mismatches(self):
         library = parse_library(open('data/library.csv'), 0.1, 1)
         assert library['m3']['thresholds'] == [1, 1]
+
+    def test_clean_allele(self):
+        raw = ['A', 'AA', 'A(1.0)', 'AA(2.4)']
+        expected = ['A', 'AA', 'A', 'AA']
+
+        out = [make_json_report.clean_allele(x) for x in raw]
+
+        assert out == expected

--- a/tests/test_tssv.py
+++ b/tests/test_tssv.py
@@ -25,9 +25,11 @@ class TestTSSV(object):
         library = parse_library(open('data/library.csv'), 0.1, 1)
         assert library['m3']['thresholds'] == [1, 1]
 
-    def test_clean_allele(self):
-        raw = ['A', 'AA', 'A(1.0)', 'AA(2.0)', 'TA(3.0)', 'ATCG(1.0)']
-        expected = ['A', 'AA', 'A', 'AAAA', 'TATATA', 'ATCG']
+    def test_expand_allele(self):
+        raw = ['A', 'AA', 'A(1.0)', 'AA(2.0)', 'TA(3.0)', 'ATCG(1.0)',
+        'ATA(2)GGG(2)C(5)']
+        expected = ['A', 'AA', 'A', 'AAAA', 'TATATA', 'ATCG',
+        'ATAATAGGGGGGCCCCC']
 
         out = [expand_allele(x) for x in raw]
 

--- a/tests/test_tssv.py
+++ b/tests/test_tssv.py
@@ -2,7 +2,7 @@
 from io import StringIO
 
 from tssv.tssv import parse_library
-from tssv.tssv import make_json_report
+from tssv.tssv import clean_allele
 
 
 class TestTSSV(object):
@@ -29,6 +29,6 @@ class TestTSSV(object):
         raw = ['A', 'AA', 'A(1.0)', 'AA(2.4)']
         expected = ['A', 'AA', 'A', 'AA']
 
-        out = [make_json_report.clean_allele(x) for x in raw]
+        out = [clean_allele(x) for x in raw]
 
         assert out == expected

--- a/tssv/cli.py
+++ b/tssv/cli.py
@@ -32,8 +32,8 @@ def main():
         '-r', dest='report_handle', type=FileType('w'), default=stdout,
         help='name of the report file')
     parser.add_argument(
-        '-j', dest='json_handle', type=FileType('w'),
-        help='name of the json output file')
+        '-f', dest='report_format', type=str, choices = ['text', 'json'],
+        default='text', help='format of the output file')
     parser.add_argument('-d', dest='path', type=str, help='output directory')
     parser.add_argument(
         '-a', dest='minimum', type=int, default=0,

--- a/tssv/cli.py
+++ b/tssv/cli.py
@@ -31,6 +31,9 @@ def main():
     parser.add_argument(
         '-r', dest='report_handle', type=FileType('w'), default=stdout,
         help='name of the report file')
+    parser.add_argument(
+        '-j', dest='json_handle', type=FileType('w'),
+        help='name of the json output file')
     parser.add_argument('-d', dest='path', type=str, help='output directory')
     parser.add_argument(
         '-a', dest='minimum', type=int, default=0,

--- a/tssv/cli.py
+++ b/tssv/cli.py
@@ -32,8 +32,8 @@ def main():
         '-r', dest='report_handle', type=FileType('w'), default=stdout,
         help='name of the report file')
     parser.add_argument(
-        '-f', dest='report_format', type=str, choices = ['text', 'json'],
-        default='text', help='format of the output file')
+        '-j', dest='json_report', action='store_true', default=False,
+        help='use json format for the output file')
     parser.add_argument('-d', dest='path', type=str, help='output directory')
     parser.add_argument(
         '-a', dest='minimum', type=int, default=0,

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -263,20 +263,21 @@ def make_text_report(tables, handle):
         write_table(tables['allele'][i]['new'], headers['allele'], handle)
 
 
+def clean_allele(allele):
+    """ Allele can be "A", or "A(1.0), and should be "A" """
+    try:
+        i = allele.index('(')
+        return allele[:i]
+    except ValueError:
+        return allele
+
+
 def make_json_report(tables, handle):
     """Make an overview of the results per marker, for downstream parsing.
 
     :arg dict tables: A nested dictionary containing overview tables.
     :arg stream handle: Open writable handle to the json file.
     """
-
-    def clean_allele(allele):
-        """ Allele can be "A", or "A(1.0), and should be "A" """
-        try:
-            i = allele.index('(')
-            return allele[:i]
-        except ValueError:
-            return allele
 
     report = dict()
 

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -324,7 +324,7 @@ def write_files(tables, files):
 
 
 def tssv(
-        input_handle, library_handle, report_handle, json_handle, path,
+        input_handle, library_handle, report_handle, report_format, path,
         threshold, mismatches, minimum, indel_score, method_sse, file_format):
     """Do the short structural variation analysis.
 
@@ -435,5 +435,7 @@ def tssv(
     if path:
         write_files(tables, files)
 
-    make_json(tables, json_handle)
-    make_report(tables, report_handle)
+    if report_format == 'text':
+        make_report(tables, report_handle)
+    if report_format == 'json':
+        make_json(tables, report_handle)

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -324,7 +324,7 @@ def write_files(tables, files):
 
 
 def tssv(
-        input_handle, library_handle, report_handle, report_format, path,
+        input_handle, library_handle, report_handle, json_report, path,
         threshold, mismatches, minimum, indel_score, method_sse, file_format):
     """Do the short structural variation analysis.
 
@@ -436,7 +436,7 @@ def tssv(
     if path:
         write_files(tables, files)
 
-    if report_format == 'text':
-        make_text_report(tables, report_handle)
-    if report_format == 'json':
+    if json_report:
         make_json_report(tables, report_handle)
+    else:
+        make_text_report(tables, report_handle)

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -4,7 +4,6 @@ from json import dump
 from math import ceil
 from os import mkdir
 from re import compile as re_compile
-from re import search
 
 from Bio import Seq, SeqIO
 
@@ -264,42 +263,6 @@ def make_text_report(tables, handle):
         write_table(tables['allele'][i]['new'], headers['allele'], handle)
 
 
-def expand_allele(allele):
-    """ Expand the allele based on the specified number of occurrences
-
-    The allele contains the nucleotide(s), as well as optionally the number
-    of occurrences of the nucleotide stretch, as specified in the library.
-
-    Here, we expand the specified nucleotides and count to the actual sequence
-
-    :arg str allele: The allele, possibly including the expected number of occurrences.
-
-    >>> expand_allele('A')
-    'A'
-
-    >>> expand_allele('A(1.0)')
-    'A'
-
-    >>> expand_allele('AA(2.0)')
-    'AAAA'
-
-    >>> expand_allele('TA(3.0)')
-    'TATATA'
-
-    >>> expand_allele('ATA(2)GGG(2)C(5)')
-    'ATAATAGGGGGGCCCCC'
-    """
-    # If there are no repeats specified, simply return the allele
-    if ')' not in allele:
-        return allele
-
-    expanded = ''
-    for pattern in allele.split(')')[:-1]:
-        nucleotides, count = pattern.split('(')
-        expanded += nucleotides*int(float(count))
-    return expanded
-
-
 def make_json_report(tables, handle):
     """Make an overview of the results per marker, for downstream parsing.
 
@@ -321,15 +284,7 @@ def make_json_report(tables, handle):
         known = [ {k:v for k,v in zip(head, mark)} for mark in data['known']]
         new = [ {k:v for k,v in zip(head, mark)} for mark in data['new']]
 
-        # Clean up the allele field, which can be "A", but also "A(1.0)"
-        for allele in known:
-            allele['allele'] = expand_allele(allele['allele'])
-        for allele in new:
-            allele['allele'] = expand_allele(allele['allele'])
-
         report['marker'][marker]['allele'] = { 'known': known, 'new': new }
-
-    #report['allele'] = with_headers
 
     ## Parse the summary data
     summary = {field:value for field,value in tables['summary']}

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -235,7 +235,7 @@ def make_tables(total, unrecognised, library, minimum):
     return tables
 
 
-def make_report(tables, handle):
+def make_text_report(tables, handle):
     """Make an overview of the results.
 
     :arg dict tables: A nested dictionary containing overview tables.
@@ -263,7 +263,7 @@ def make_report(tables, handle):
         write_table(tables['allele'][i]['new'], headers['allele'], handle)
 
 
-def make_json(tables, handle):
+def make_json_report(tables, handle):
     """Make an overview of the results per marker, for downstream parsing.
 
     :arg dict tables: A nested dictionary containing overview tables.
@@ -331,6 +331,7 @@ def tssv(
     :arg stream input_handle: Open readable handle to a FASTA file.
     :arg stream library_handle: Open readable handle to a library file.
     :arg stream report_handle: Open writable handle to the report file.
+    :arg str report_format: Format for the report file.
     :arg str path: Name of the output folder.
     :arg float threshold: Number of allowed mismatches per nucleotide.
     :arg int mismatches: If set, overrides the dynamic threshold calculation.
@@ -436,6 +437,6 @@ def tssv(
         write_files(tables, files)
 
     if report_format == 'text':
-        make_report(tables, report_handle)
+        make_text_report(tables, report_handle)
     if report_format == 'json':
-        make_json(tables, report_handle)
+        make_json_report(tables, report_handle)

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -269,6 +269,9 @@ def make_json(tables, handle):
     :arg dict tables: A nested dictionary containing overview tables.
     :arg stream handle: Open writable handle to the json file.
     """
+    report = dict()
+
+    ## Parse the allele data
     alleles  = tables['allele']
     head = headers['allele'].strip().split('\t')
 
@@ -279,7 +282,23 @@ def make_json(tables, handle):
         new = [ {k:v for k,v in zip(head, mark)} for mark in data['new']]
         with_headers[marker] = { 'known': known, 'new': new }
 
-    json.dump(with_headers, indent=True, fp=handle)
+    report['allele'] = with_headers
+
+    ## Parse the summary data
+    summary = {field:value for field,value in tables['summary']}
+    report['summary'] = summary
+
+    ## Parse library data
+    head = headers['markers'].strip().split('\t')
+
+    library = dict()
+    for i in tables['library']:
+        row = {field:value for field, value in zip(head, i)}
+        marker = row.pop('name')
+        library[marker] = row
+    report['library'] = library
+
+    json.dump(report, indent=True, fp=handle)
 
 
 def write_files(tables, files):
@@ -416,5 +435,5 @@ def tssv(
     if path:
         write_files(tables, files)
 
-    make_report(tables, report_handle)
     make_json(tables, json_handle)
+    make_report(tables, report_handle)

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -269,6 +269,15 @@ def make_json_report(tables, handle):
     :arg dict tables: A nested dictionary containing overview tables.
     :arg stream handle: Open writable handle to the json file.
     """
+
+    def clean_allele(allele):
+        """ Allele can be "A", or "A(1.0), and should be "A" """
+        try:
+            i = allele.index('(')
+            return allele[:i]
+        except ValueError:
+            return allele
+
     report = dict()
 
     ## Parse the allele data
@@ -282,6 +291,13 @@ def make_json_report(tables, handle):
         report['marker'][marker] = dict()
         known = [ {k:v for k,v in zip(head, mark)} for mark in data['known']]
         new = [ {k:v for k,v in zip(head, mark)} for mark in data['new']]
+
+        # Clean up the allele field, which can be "A", but also "A(1.0)"
+        for allele in known:
+            allele['allele'] = clean_allele(allele['allele'])
+        for allele in new:
+            allele['allele'] = clean_allele(allele['allele'])
+
         report['marker'][marker]['allele'] = { 'known': known, 'new': new }
 
     #report['allele'] = with_headers

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -275,14 +275,16 @@ def make_json_report(tables, handle):
     alleles  = tables['allele']
     head = headers['allele'].strip().split('\t')
 
-    # Add the allele headers to the results dictionary
-    with_headers = dict()
+    # Add 'marker' section to the json report
+    report['marker'] = dict()
     for marker, data in alleles.items():
+        # Add the individual marker to the report
+        report['marker'][marker] = dict()
         known = [ {k:v for k,v in zip(head, mark)} for mark in data['known']]
         new = [ {k:v for k,v in zip(head, mark)} for mark in data['new']]
-        with_headers[marker] = { 'known': known, 'new': new }
+        report['marker'][marker]['allele'] = { 'known': known, 'new': new }
 
-    report['allele'] = with_headers
+    #report['allele'] = with_headers
 
     ## Parse the summary data
     summary = {field:value for field,value in tables['summary']}
@@ -291,12 +293,12 @@ def make_json_report(tables, handle):
     ## Parse library data
     head = headers['markers'].strip().split('\t')
 
-    library = dict()
     for i in tables['library']:
         row = {field:value for field, value in zip(head, i)}
         marker = row.pop('name')
-        library[marker] = row
-    report['library'] = library
+        report['marker'][marker]['library'] = row
+        #library[marker] = row
+    #report['library'] = library
 
     json.dump(report, indent=True, fp=handle)
 

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -314,8 +314,6 @@ def make_json_report(tables, handle):
         row = {field:value for field, value in zip(head, i)}
         marker = row.pop('name')
         report['marker'][marker]['library'] = row
-        #library[marker] = row
-    #report['library'] = library
 
     dump(report, indent=True, fp=handle)
 

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import reduce
-import json
+from json import dump
 from math import ceil
 from os import mkdir
 from re import compile as re_compile
@@ -300,7 +300,7 @@ def make_json_report(tables, handle):
         #library[marker] = row
     #report['library'] = library
 
-    json.dump(report, indent=True, fp=handle)
+    dump(report, indent=True, fp=handle)
 
 
 def write_files(tables, files):

--- a/tssv/tssv.py
+++ b/tssv/tssv.py
@@ -272,23 +272,32 @@ def expand_allele(allele):
 
     Here, we expand the specified nucleotides and count to the actual sequence
 
-    A       -> A
-    A(1.0)  -> A
-    AA(2.0) -> AAAA
-    TA(3.0) -> TATATA
     :arg str allele: The allele, possibly including the expected number of occurrences.
-    """
-    result = search("([ATCGN]+)((.*))", allele)
-    allele = result.group(1)
-    count = result.group(2)
 
-    # If no count between brackets was present
-    if not count:
+    >>> expand_allele('A')
+    'A'
+
+    >>> expand_allele('A(1.0)')
+    'A'
+
+    >>> expand_allele('AA(2.0)')
+    'AAAA'
+
+    >>> expand_allele('TA(3.0)')
+    'TATATA'
+
+    >>> expand_allele('ATA(2)GGG(2)C(5)')
+    'ATAATAGGGGGGCCCCC'
+    """
+    # If there are no repeats specified, simply return the allele
+    if ')' not in allele:
         return allele
-    else:
-        # Cut off the brackets and convert to int
-        count = int(float(count[1:-1]))
-        return allele*count
+
+    expanded = ''
+    for pattern in allele.split(')')[:-1]:
+        nucleotides, count = pattern.split('(')
+        expanded += nucleotides*int(float(count))
+    return expanded
 
 
 def make_json_report(tables, handle):


### PR DESCRIPTION
## Pull Request Details
This pull request adds a new output file with command line option, `-j`, which contains the results for each marker in json format. This makes it easier to perform downstream processing on the TSSV results.

## Breaking Changes
None

## Issues Fixed
None

## Other Relevant Information
Below is a comparison between the data from the regular, and the new json report.

### The regular report from tssv
```
known alleles for marker chrM:152:
allele  total   forward reverse

new alleles for marker chrM:152 (mean length 1.0):
allele  total   forward reverse
C       27      8       19

known alleles for marker chrM:263:
allele  total   forward reverse

new alleles for marker chrM:263 (mean length 1.0):
allele  total   forward reverse
G       21      3       18

known alleles for marker chrM:302:
allele  total   forward reverse

new alleles for marker chrM:302 (mean length 3.111111111111111):
allele  total   forward reverse
ACC     16      0       16
ACCC    2       0       2
```
### The json report
```json
{
 "chrM:152": {
  "known": [],
  "new": [
   {
    "allele": "C",
    "total": 27,
    "forward": 8,
    "reverse": 19
   }
  ]
 },
 "chrM:263": {
  "known": [],
  "new": [
   {
    "allele": "G",
    "total": 21,
    "forward": 3,
    "reverse": 18
   }
  ]
 },
 "chrM:302": {
  "known": [],
  "new": [
   {
    "allele": "ACC",
    "total": 16,
    "forward": 0,
    "reverse": 16
   },
   {
    "allele": "ACCC",
    "total": 2,
    "forward": 0,
    "reverse": 2
   }
  ]
 }
```

[1]: https://github.com/jfjlaros/tssv/pulls
[2]: https://github.com/jfjlaros/tssv/blob/master/docs/CONTRIBUTING.md#code-style
